### PR TITLE
Added possibility to use Drill 2 online instance as offline app

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ One instance of Drill 2 is [publicly available](https://gronostajo.github.io/dri
 
 Feel free to download or fork the source code and make your own changes. Then you can deploy the application for yourself or for wider audience. (Please mind the [license](https://github.com/gronostajo/drill2/blob/master/LICENSE)!)
 
+In order to enable using your Drill 2 instance as offline app, you need to serve `drill2.appcache` with MIME type `text/cache-manifest`.
+
 ## Question banks
 
 Questions are loaded from ordinary text files with human-readable structure. You can load those files from your computer's hard disk or device's memory, or, if your browser doesn't support File API, you can manually paste file contents into Drill 2.

--- a/drill2.appcache
+++ b/drill2.appcache
@@ -1,0 +1,18 @@
+CACHE MANIFEST
+# rev 20140705-1
+CACHE:
+https://ajax.googleapis.com/ajax/libs/angularjs/1.2.18/angular.min.js
+https://ajax.googleapis.com/ajax/libs/angularjs/1.2.18/angular.min.js.map
+https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js
+https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css
+https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/fonts/glyphicons-halflings-regular.svg
+https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/fonts/glyphicons-halflings-regular.ttf
+https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/fonts/glyphicons-halflings-regular.woff
+https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js
+https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js
+res/controller.js
+res/jquery.cookie-1.4.1.min.js
+res/localfile.js
+res/markdown.min.js
+res/script.js
+res/style.css

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="DrillApp">
+<html ng-app="DrillApp" manifest="drill2.appcache">
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
This simple change allows to use HTML5 AppCache for online-hosted Drill 2 instance. This makes it possible to use it without Internet connection.

If any external resources are added or updated, they have to be included in cache manifest. If Drill 2 resources are changed (but there are no changes to their names), manifest revision number must be bumped (any changes to manifest file trigger client-side cache update).

**Note:** I'm not sure whether this would affect external resources in questions (images embedded using Markdown). It may be necessary to add

```
NETWORK:
*
```

to AppCache manifest file if external images are visible only on the first page load and disappear on subsequent reloads.
