### PR TITLE
Qol improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "coffee-script": "1.10.0",
     "coffeelint": "1.15.7",
     "coffeelint-newline-at-eof": "0.4.1",
+    "coffeescript": "^2.7.0",
     "del": "2.2.x",
     "group-array": "^0.3.1",
     "gulp": "3.9.1",
@@ -37,6 +38,9 @@
     "run-sequence": "1.2.2",
     "yargs": "5.0.0"
   },
+  "overrides": {
+    "graceful-fs": "^4.2.11"
+  },  
   "repository": {
     "type": "git",
     "url": "git://github.com/gronostajo/drill2.git"

--- a/src/app/20_main.js
+++ b/src/app/20_main.js
@@ -193,6 +193,8 @@
 				}
 			}
 
+			if ($scope.view.isGraded()) return;
+
 			for (i = 0; i < $scope.currentQuestion.answers.length; i++) {
 				sortingKeys.push($scope.currentQuestion.answers[i].sortingKey);
 			}

--- a/src/app/20_main.js
+++ b/src/app/20_main.js
@@ -151,6 +151,8 @@
 
 			$scope.currentQuestion = $scope.questions[$scope.questionIndex - 1];
 
+			$scope.displayAsRadio = $scope.config.displayAsRadio && $scope.currentQuestion.totalCorrect() == 1;
+
 			for (var i = 0; i < $scope.questions.length; i++) {
 				var q = $scope.questions[i];
 				for (var j = 0; j < q.answers.length; j++) {
@@ -162,6 +164,7 @@
 			for (var i = 0; i < $scope.currentQuestion.answers.length; i++) {
 				$scope.currentQuestion.answers[i].checked = false;
 			}
+			$scope.currentQuestion.checkedAnswer = undefined; // for radio input questions
 
 			ViewportHelper.scrollToTop(function() {
 				$scope.$apply(function () {
@@ -211,12 +214,20 @@
 
 			for (i = 0; i < $scope.currentQuestion.answers.length; i++) {
 				if ($scope.currentQuestion.answers[i].sortingKey === sortingKeys[$event.which - 49]) {
-					$scope.currentQuestion.answers[i].checked = !$scope.currentQuestion.answers[i].checked;
+					if ($scope.displayAsRadio)
+						$scope.currentQuestion.checkedAnswer = $scope.currentQuestion.answers[i].id; // for radio input questions
+					else
+						$scope.currentQuestion.answers[i].checked = !$scope.currentQuestion.answers[i].checked;
 				}
 			}
 		};
 
 		$scope.grade = function () {
+			// kind of dirty workaround for grading radio questions but hey it works
+			for (const answer of $scope.currentQuestion.answers) {
+				if (answer.id == $scope.currentQuestion.checkedAnswer) answer.checked = true;
+			}
+
 			$scope.stopTimer();
 
 			$scope.view.current = 'graded';
@@ -315,6 +326,7 @@
 				for (var i = 0; i < $scope.currentQuestion.answers.length; i++) {
 					$scope.currentQuestion.answers[i].checked = false;
 				}
+				$scope.currentQuestion.checkedAnswer = undefined; // for radio input questions
 				$scope.grade();
 				$scope.stopTimer();
 			}

--- a/src/app/20_main.js
+++ b/src/app/20_main.js
@@ -223,8 +223,8 @@
 		};
 
 		$scope.grade = function () {
-			// kind of dirty workaround for grading radio questions but hey it works
-			for (const answer of $scope.currentQuestion.answers) {
+			for (var i = 0; i < $scope.currentQuestion.answers.length; i++) {
+				var answer = $scope.currentQuestion.answers[i];
 				if (answer.id == $scope.currentQuestion.checkedAnswer) answer.checked = true;
 			}
 

--- a/src/app/20_main.js
+++ b/src/app/20_main.js
@@ -151,6 +151,14 @@
 
 			$scope.currentQuestion = $scope.questions[$scope.questionIndex - 1];
 
+			for (var i = 0; i < $scope.questions.length; i++) {
+				var q = $scope.questions[i];
+				for (var j = 0; j < q.answers.length; j++) {
+					q.answers[j].sortingKey = ($scope.config.shuffleAnswers)
+						? Math.random() : j;
+				}
+			}
+
 			for (var i = 0; i < $scope.currentQuestion.answers.length; i++) {
 				$scope.currentQuestion.answers[i].checked = false;
 			}
@@ -239,14 +247,6 @@
 			}
 			else {
 				$scope.questions = $scope.loadedQuestions.slice(0);	// shallow copy
-			}
-
-			for (var i = 0; i < $scope.questions.length; i++) {
-				var q = $scope.questions[i];
-				for (var j = 0; j < q.answers.length; j++) {
-					q.answers[j].sortingKey = ($scope.config.shuffleAnswers)
-						? Math.random() : j;
-				}
 			}
 		};
 

--- a/src/app/parser/meta/OptionsBlockProcessor.coffee
+++ b/src/app/parser/meta/OptionsBlockProcessor.coffee
@@ -86,6 +86,8 @@ angular.module('DrillApp').service 'OptionsBlockProcessor', (JsonLoader, SafeEva
 
     repeatIncorrect: parseBool
 
+    displayAsRadio: parseBool
+
     explain: (vOrig, m, logFn) ->
       v = vOrig and vOrig.toLowerCase()
       if v in ['summary', 'optional', 'always']

--- a/src/app/screens/home/settings/settings.html
+++ b/src/app/screens/home/settings/settings.html
@@ -108,6 +108,12 @@
                         Repeat incorrectly answered questions
                     </label>
                 </div>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" ng-model="model.displayAsRadio">
+                        Display questions with one correct answer as Radio (only one option at a time is selectable)
+                    </label>
+                </div>
             </div>
         </div>
 

--- a/src/app/screens/question/question.html
+++ b/src/app/screens/question/question.html
@@ -16,10 +16,11 @@
         <div ng-hide="config.markdown" ng-bind-html="currentQuestion.body | plaintext"></div>
     </div>
     <div class="form-group answers">
-        <div class="checkbox answer no-selection correct-{{answer.correct}} checked-{{answer.checked}}" ng-class="{ explained: view.isGraded() && config.showExplanations && currentQuestion.hasExplanations }" ng-repeat="answer in currentQuestion.answers | orderBy:'sortingKey'">
+        <div class="{{displayAsRadio ? 'radio' : 'checkbox'}} answer no-selection correct-{{answer.correct}} checked-{{displayAsRadio ? (currentQuestion.checkedAnswer == answer.id) : answer.checked}}" ng-class="{ explained: view.isGraded() && config.showExplanations && currentQuestion.hasExplanations }" ng-repeat="answer in currentQuestion.answers | orderBy:'sortingKey'">
             <label>
                 <span class="label label-default keyboard-shortcut answer-number"></span>
-                <input type="checkbox" ng-model="answer.checked" ng-disabled="view.isGraded()">
+                <input type="radio" ng-model="currentQuestion.checkedAnswer" ng-value="answer.id" ng-disabled="view.isGraded()" ng-if="displayAsRadio">
+                <input type="checkbox" ng-model="answer.checked" ng-disabled="view.isGraded()" ng-else>
                 <span class="content">
                     <span class="id" ng-show="view.isGraded() && config.showExplanations && currentQuestion.hasExplanations">{{answer.id}})&nbsp</span>
                     <span ng-bind-html="answer.body | plaintext:'span.p'"></span>

--- a/src/app/screens/summary/summary.html
+++ b/src/app/screens/summary/summary.html
@@ -10,9 +10,9 @@
         <div class="panel-body">
             <div class="question-body" ng-show="config.markdown" ng-bind-html="question.body | markdown:this"></div>
             <div class="question-body" ng-hide="config.markdown" ng-bind-html="question.body | plaintext"></div>
-            <div class="checkbox answer explained" ng-repeat="answer in question.answers">
+            <div class="{{(config.displayAsRadio && question.totalCorrect() == 1) ? 'radio' : 'checkbox'}} answer explained" ng-repeat="answer in question.answers">
                 <label ng-class="{ correct: answer.checked && answer.correct, incorrect: answer.checked && !answer.correct, missed: !answer.checked && answer.correct }">
-                    <input type="checkbox" disabled ng-checked="answer.checked">
+                    <input type="{{(config.displayAsRadio && question.totalCorrect() == 1) ? 'radio' : 'checkbox'}}" disabled ng-checked="answer.checked">
                     <span class="content">
                         <span class="id">{{answer.id}})&nbsp;</span>
                         <span ng-bind-html="answer.body | plaintext:'span.p'"></span>

--- a/test/src/parser/meta/OptionsBlockProcessorSpec.coffee
+++ b/test/src/parser/meta/OptionsBlockProcessorSpec.coffee
@@ -16,6 +16,7 @@ describe 'OptionsBlockProcessor', ->
     timeLimitEnabled: no
     timeLimitSecs: 60
     repeatIncorrect: no
+    displayAsRadio: no
     explain: 'optional'
     showExplanations: no
     explanations: {}
@@ -179,6 +180,27 @@ describe 'OptionsBlockProcessor', ->
     expect(@OptionsBlockProcessor.process('{"repeatIncorrect": "no"}', logger)).toHaveMemberValues(expectedFalse)
     expect(@OptionsBlockProcessor.process('{"repeatIncorrect": "0"}', logger)).toHaveMemberValues(expectedFalse)
     expect(@OptionsBlockProcessor.process('{"repeatIncorrect": 0}', logger)).toHaveMemberValues(expectedFalse)
+
+    expect(logger).not.toHaveBeenCalled()
+
+  it 'should recognize display as radio setting option', ->
+    expectedTrue = displayAsRadio: yes
+    expectedFalse = displayAsRadio: no
+    logger = jasmine.createSpy('logger')
+
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": true}', logger)).toHaveMemberValues(expectedTrue)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "true"}', logger)).toHaveMemberValues(expectedTrue)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "enabled"}', logger)).toHaveMemberValues(expectedTrue)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "yes"}', logger)).toHaveMemberValues(expectedTrue)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "1"}', logger)).toHaveMemberValues(expectedTrue)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": 1}', logger)).toHaveMemberValues(expectedTrue)
+
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": false}', logger)).toHaveMemberValues(expectedFalse)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "false"}', logger)).toHaveMemberValues(expectedFalse)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "disabled"}', logger)).toHaveMemberValues(expectedFalse)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "no"}', logger)).toHaveMemberValues(expectedFalse)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": "0"}', logger)).toHaveMemberValues(expectedFalse)
+    expect(@OptionsBlockProcessor.process('{"displayAsRadio": 0}', logger)).toHaveMemberValues(expectedFalse)
 
     expect(logger).not.toHaveBeenCalled()
 


### PR DESCRIPTION
1. Close #13 by adding option to mark the test as containing single-answer questions. Those will be displayed as Radio. Multiple-answer questions will be still displayed as Checkbox regardless of this setting.
2. Remove possibility to edit checked answers using keyboard input after the question was already graded.
3. Shuffle answers every time a question is loaded, as opposed to only once while initializing the whole test. This is useful when using "Shuffle answers" together with "Repeat incorrectly answered questions".

Additionally, a workaround was needed in order for old Gulp version to work with modern Node versions.
All unit tests are passing now, I also added new test for "Display as Radio" option.